### PR TITLE
docs: add power meter documentation and json array syntax note

### DIFF
--- a/docs/firmware/configuration/power_meter.md
+++ b/docs/firmware/configuration/power_meter.md
@@ -1,0 +1,20 @@
+# Power Meter Configuration
+
+This section describes how to connect external power meters via the web interface to read grid power data for the battery control system.
+
+## HTTP/JSON Provider
+
+The HTTP/JSON provider allows you to query power meters that expose their data locally via a REST API in JSON format (e.g., Shelly 3EM, Tasmota, etc.).
+
+### Important Note on JSON Path Syntax (Arrays)
+
+The internal parser utilizes a **JSON Pointer logic** and splits paths exclusively by forward slashes (`/`). The classic JavaScript dot-notation with directly attached brackets will not work and results in errors (e.g., `Unable to access JSON key...`).
+
+If your meter's JSON response contains nested arrays/lists (identifiable by square brackets, e.g., for individual phase values), the array index must be isolated using forward slashes.
+
+* **Incorrect:** `emeters[1].power` or `emeters[1]/power`
+* **Correct:** `emeters/[1]/power` (or with a leading slash: `/emeters/[1]/power`)
+
+### Example: Shelly 3EM
+To read the power value of the second phase (L2) from a Shelly 3EM, the correct path configuration is:
+`emeters/[1]/power`


### PR DESCRIPTION
Hi! 

I noticed there was no dedicated documentation file or detailed guide for the HTTP/JSON Power Meter configuration yet. 

After struggling to connect a Shelly 3EM because of nested arrays, I found out that the internal parser expects a strict JSON Pointer format (`emeters/[1]/power`) instead of standard dot-notation (`emeters[1].power`). 

To save other users from running into the `Unable to access JSON key...` error, I created this `power_meter.md` file to properly document the setup and the required syntax. 

Please let me know if it fits here or if I should move the note somewhere else. Thanks!