### PR TITLE
Add dependabot config for github-actions and pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for pip
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` so GitHub Actions and pip dependencies get scheduled update PRs, mirroring the schedule used in the OpenDTU-OnBattery firmware repo (`github-actions`: daily, `pip`: weekly).
- Previously this repo had no version-update automation at all; the only Dependabot activity seen (`dependabot/pip/pip-*` branches) was automatic security-alert patching, not routine bumps. Action/dependency version bumps only reached this repo by chance via upstream cherry-picks (e.g. the `actions/checkout@v4→v5` bump).

## Test plan
- [ ] Merge and confirm Dependabot opens PRs on the configured schedule